### PR TITLE
feat: complete skill-claude-code handler with session accessors and audit logger

### DIFF
--- a/skills/skill-claude-code/audit-log.ts
+++ b/skills/skill-claude-code/audit-log.ts
@@ -1,0 +1,106 @@
+/**
+ * Audit Logger for skill-claude-code
+ *
+ * SQLite-backed audit trail for all operations.
+ * Provides in-memory variant for testing.
+ */
+
+import Database from "better-sqlite3";
+
+// ── Types ──
+
+export interface AuditLogEntry {
+  timestamp: string;
+  skill: string;
+  action: string;
+  target: string;
+  result: "success" | "failure" | "error";
+  details: Record<string, unknown>;
+}
+
+export interface AuditLogger {
+  log(entry: Omit<AuditLogEntry, "timestamp">): void;
+  query(filters?: { skill?: string; action?: string; limit?: number }): AuditLogEntry[];
+  close(): void;
+}
+
+// ── Schema ──
+
+const CREATE_TABLE = `
+  CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL DEFAULT (datetime(now)),
+    skill TEXT NOT NULL,
+    action TEXT NOT NULL,
+    target TEXT NOT NULL,
+    result TEXT NOT NULL,
+    details TEXT NOT NULL DEFAULT {}
+  )
+`;
+
+const CREATE_INDEX = `
+  CREATE INDEX IF NOT EXISTS idx_audit_skill_action ON audit_log (skill, action)
+`;
+
+// ── Implementation ──
+
+function createLogger(db: InstanceType<typeof Database>): AuditLogger {
+  db.exec(CREATE_TABLE);
+  db.exec(CREATE_INDEX);
+
+  const insertStmt = db.prepare(
+    "INSERT INTO audit_log (skill, action, target, result, details) VALUES (?, ?, ?, ?, ?)",
+  );
+
+  const queryStmt = db.prepare(
+    "SELECT * FROM audit_log WHERE (?1 IS NULL OR skill = ?1) AND (?2 IS NULL OR action = ?2) ORDER BY id DESC LIMIT ?3",
+  );
+
+  return {
+    log(entry) {
+      insertStmt.run(
+        entry.skill,
+        entry.action,
+        entry.target,
+        entry.result,
+        JSON.stringify(entry.details),
+      );
+    },
+    query(filters) {
+      const rows = queryStmt.all(
+        filters?.skill ?? null,
+        filters?.action ?? null,
+        filters?.limit ?? 100,
+      ) as Array<{
+        timestamp: string;
+        skill: string;
+        action: string;
+        target: string;
+        result: string;
+        details: string;
+      }>;
+
+      return rows.map((row) => ({
+        ...row,
+        result: row.result as AuditLogEntry["result"],
+        details: JSON.parse(row.details),
+      }));
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+// ── Factory functions ──
+
+export function createAuditLogger(dbPath: string): AuditLogger {
+  const db = new Database(dbPath);
+  db.pragma("journal_mode = WAL");
+  return createLogger(db);
+}
+
+export function createInMemoryDatabase(): AuditLogger {
+  const db = new Database(":memory:");
+  return createLogger(db);
+}

--- a/skills/skill-claude-code/handler.ts
+++ b/skills/skill-claude-code/handler.ts
@@ -646,3 +646,17 @@ function formatDuration(ms: number): string {
   const sec = totalSec % 60;
   return min > 0 ? `${min}分${sec}秒` : `${sec}秒`;
 }
+
+// ── Session accessors (for external consumers) ──
+
+export function getSession(id: string): SessionInfo | undefined {
+  return sessions.get(id);
+}
+
+export function listSessions(): SessionInfo[] {
+  return Array.from(sessions.values());
+}
+
+export function clearSessions(): void {
+  sessions.clear();
+}


### PR DESCRIPTION
## Summary
- Add `getSession`, `listSessions`, `clearSessions` exports to handler.ts for external consumers
- Create `audit-log.ts` with SQLite-backed audit trail (WAL mode) + in-memory variant for testing

Closes #4

## Sprint 1
- Task: #4 skill-claude-code handler.ts 実装 (SP: 5)
- Parent: #1 スクラムエージェント安定化

## Test plan
- [ ] handler.ts exports compile correctly
- [ ] audit-log.ts creates SQLite DB and logs entries
- [ ] createInMemoryDatabase() works for tests